### PR TITLE
Run semiconductor QA with vLLM

### DIFF
--- a/run_semiconductor_qa.py
+++ b/run_semiconductor_qa.py
@@ -1021,13 +1021,13 @@ def main():
     
     # 运行异步流程
     asyncio.run(run_complete_pipeline(
+        config=config if args.config else {},  # 传入配置
         input_dir=args.input_dir,
         output_dir=args.output_dir,
         model_name=args.model,
         batch_size=args.batch_size,
         gpu_devices=args.gpu_devices,
         enable_full_steps=args.enable_full_steps
-        config=config  # ✅ 补上这一行
     ))
 
 


### PR DESCRIPTION
Fix syntax error in `run_semiconductor_qa.py` to correctly pass the configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd4a2cd9-bb84-4c54-a532-156e9ab041ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd4a2cd9-bb84-4c54-a532-156e9ab041ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

