### PR TITLE
Process semiconductor qa data with vllm

### DIFF
--- a/LocalModels/local_model_manager.py
+++ b/LocalModels/local_model_manager.py
@@ -158,6 +158,27 @@ class LocalModelManager:
         if VLLM_HTTP_AVAILABLE:
             backends.append('vllm_http')
         return backends
+    
+    def is_available(self):
+        """
+        检查当前配置的后端是否可用
+        
+        Returns:
+            bool: 如果当前后端可用则返回True，否则返回False
+        """
+        try:
+            if self.backend == "vllm_http":
+                return VLLM_HTTP_AVAILABLE
+            elif self.backend == "vllm":
+                return VLLM_AVAILABLE
+            elif self.backend == "ollama":
+                # Ollama默认认为是可用的，因为它不需要额外依赖
+                return True
+            else:
+                return False
+        except Exception as e:
+            logger.error(f"Error checking backend availability: {e}")
+            return False
 
 
 def create_local_model_manager(config: Optional[Dict[str, Any]] = None) -> LocalModelManager:


### PR DESCRIPTION
Add `is_available` method to `LocalModelManager` to fix `AttributeError`.

This method was missing, causing an `AttributeError` when the system attempted to check the availability of local model managers. The added method now correctly checks the availability based on the configured backend (vllm_http, vllm, ollama).

---
<a href="https://cursor.com/background-agent?bcId=bc-b8be4c4a-8019-494d-9f69-7bc2a40f24d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8be4c4a-8019-494d-9f69-7bc2a40f24d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

