### PR TITLE
Fix semiconductor qa model path

### DIFF
--- a/LocalModels/vllm_client.py
+++ b/LocalModels/vllm_client.py
@@ -62,7 +62,7 @@ class VLLMClient:
                 - max_tokens: 最大生成令牌数
         """
         self.config = config
-        self.model_path = config.get('model_path', '/mnt/workspace/models/Qwen/QwQ-32B/')
+        self.model_path = config.get('model_path', 'Qwen/QwQ-32B-Preview')
         self.llm = None
         self.tokenizer = None
         self.sampling_params = None

--- a/semiconductor_qa_generator.py
+++ b/semiconductor_qa_generator.py
@@ -80,7 +80,7 @@ class ModelConfig:
 MODEL_CONFIGS = {
     "qwq_32": ModelConfig(
         name="qwq_32",
-        path="/mnt/workspace/models/Qwen/QwQ-32B/",
+        path="Qwen/QwQ-32B-Preview",
         stop_tokens=[151329, 151336, 151338]
     ),
     "qw2_72": ModelConfig(


### PR DESCRIPTION
Update model paths to use Hugging Face ID `Qwen/QwQ-32B-Preview`.

The previous local model path `/mnt/workspace/models/Qwen/QwQ-32B/` was invalid, causing a `ValidationError` during vLLM initialization. This change ensures the model can be correctly loaded by allowing vLLM to download and cache it from the Hugging Face model hub.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a10c155-24af-49c5-b798-b90acc980971">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a10c155-24af-49c5-b798-b90acc980971">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

